### PR TITLE
Add basic util tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "date-fns": "^4.1.0",
@@ -25,6 +26,7 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "vitest": "^2.1.5"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import TopBar from './components/TopBar';
 import Calendar from './components/Calendar';
 import NotesPanel from './components/NotesPanel';

--- a/src/components/NotesPanel.tsx
+++ b/src/components/NotesPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { formatDateForDisplay, formatDateTimeForDisplay, formatTimeForDisplay } from '../utils/dateHelpers';
 import { generateNoteId } from '../utils/notesStorage';
 import type { Note, DateKey, NotesActions } from '../types/notes';
@@ -23,7 +23,7 @@ const NotesPanel: React.FC<NotesPanelProps> = ({
   const [editorContent, setEditorContent] = useState('');
   const [saveStatus, setSaveStatus] = useState('');
   const editorRef = useRef<HTMLTextAreaElement>(null);
-  const debounceRef = useRef<NodeJS.Timeout>();
+  const debounceRef = useRef<number | null>(null);
 
   const selectedNote = notes.find(note => note.id === selectedNoteId);
   const sortedNotes = [...notes].sort((a, b) => 

--- a/src/hooks/useNotesState.ts
+++ b/src/hooks/useNotesState.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { saveNotesToStorage, loadNotesFromStorage, generateNoteId } from '../utils/notesStorage';
 import type { NotesState, NotesActions, Note, DateKey } from '../types/notes';
 

--- a/src/utils/calendarHelpers.test.ts
+++ b/src/utils/calendarHelpers.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { formatMonthYear, getCurrentYearMonth, isCurrentMonth } from './calendarHelpers';
+
+describe('calendarHelpers', () => {
+  it('returns current year and month', () => {
+    const { year, month } = getCurrentYearMonth();
+    const now = new Date();
+    expect(year).toBe(now.getFullYear());
+    expect(month).toBe(now.getMonth());
+  });
+
+  it('formats month and year', () => {
+    expect(formatMonthYear(2024, 0)).toBe('January 2024');
+  });
+
+  it('checks if date is in current month', () => {
+    expect(isCurrentMonth(new Date(2024, 0, 15), 2024, 0)).toBe(true);
+  });
+});

--- a/src/utils/dateHelpers.test.ts
+++ b/src/utils/dateHelpers.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { dateKeyToDate, dateToDateKey, formatDateForDisplay } from './dateHelpers';
+
+describe('dateHelpers', () => {
+  it('converts date to date key and back', () => {
+    const date = new Date('2024-01-02');
+    const key = dateToDateKey(date);
+    expect(key).toBe('2024-01-02');
+    const parsed = dateKeyToDate(key);
+    expect(parsed.toISOString().slice(0, 10)).toBe('2024-01-02');
+  });
+
+  it('formats date for display', () => {
+    const display = formatDateForDisplay('2024-01-02');
+    expect(display).toContain('2024-01-02');
+  });
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -23,5 +23,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary
- add Vitest script and dev dependency
- cover date and calendar helpers with basic tests
- fix lint/type issues in hooks and components

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc4385e040832c92dfa9adbf5f6e52